### PR TITLE
Disable sensor simulation and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ## Proyecto Demo MQTT
 
-Demostración sobre el uso MQTT utilizando Java, 
-creando Publicadores y Subcriptores mediante el servidor externo de
-Mosquitto.
+Aplicación en Java que se suscribe a un broker MQTT y almacena en una base de
+datos las mediciones enviadas desde un sensor BM280 conectado a un ESP32.
+Anteriormente esta aplicación generaba datos simulados, pero ahora únicamente
+consume los valores recibidos.
 
 ### Ejecutar directamente desde los fuentes
 

--- a/src/main/java/org/javadominicano/cmp/Main.java
+++ b/src/main/java/org/javadominicano/cmp/Main.java
@@ -5,12 +5,8 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 
 public class Main {
     public static void main(String[] args) {
-        // 👉 Esto inicia los hilos de publicación
-        try {
-            Publicador.iniciarPrueba();  // << LÍNEA QUE FALTABA
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        // 👉 Se eliminó la simulación de datos. Ahora solo se escuchan los
+        //    mensajes enviados por los sensores reales a través de MQTT.
 
         String broker = "tcp://mqtt.eict.ce.pucmm.edu.do:1883";
         String usuario = "itt363-grupo1";


### PR DESCRIPTION
## Summary
- stop launching the publisher threads that generated fake data
- clarify in the README that real BM280/ESP32 sensor data is used

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686b0593e9a88322b69fcc2b99abafd6