### PR TITLE
Add pressure and soil humidity sensor support

### DIFF
--- a/src/main/java/org/javadominicano/cmp/Main.java
+++ b/src/main/java/org/javadominicano/cmp/Main.java
@@ -29,6 +29,7 @@ public class Main {
             client.subscribe("/itt363-grupo1/estacion-1/sensores/temperatura");
             client.subscribe("/itt363-grupo1/estacion-1/sensores/presion");
             client.subscribe("/itt363-grupo1/estacion-1/sensores/humedad");
+            client.subscribe("/itt363-grupo1/estacion-1/sensores/humedad_suelo");
             client.subscribe("/itt363-grupo1/estacion-1/sensores/precipitacion");
             //client.subscribe("/itt363-grupo1/estacion-1/sensores/datos");
             //client.subscribe("/itt363-grupo1/estacion-2/sensores/datos");

--- a/src/main/java/org/javadominicano/cmp/Publicador.java
+++ b/src/main/java/org/javadominicano/cmp/Publicador.java
@@ -87,6 +87,26 @@ public class Publicador {
                 esperar(8000);
             }
         }).start();
+
+        // Presión atmosférica cada 9 segundos
+        new Thread(() -> {
+            while (true) {
+                Sensor s = new Sensor("sensor6", "presion");
+                new Publicador("pub-presion").enviarMensaje(
+                        "/itt363-grupo1/estacion-1/sensores/presion", gson.toJson(s));
+                esperar(9000);
+            }
+        }).start();
+
+        // Humedad del suelo cada 10 segundos
+        new Thread(() -> {
+            while (true) {
+                Sensor s = new Sensor("sensor7", "humedad_suelo");
+                new Publicador("pub-humedad-suelo").enviarMensaje(
+                        "/itt363-grupo1/estacion-1/sensores/humedad_suelo", gson.toJson(s));
+                esperar(10000);
+            }
+        }).start();
     }
 
     private static void esperar(int milis) {

--- a/src/main/java/org/javadominicano/cmp/Sensor.java
+++ b/src/main/java/org/javadominicano/cmp/Sensor.java
@@ -6,7 +6,8 @@ import java.util.Random;
 
 public class Sensor {
     private String sensorId;
-    private String tipo;  // velocidad, direccion, humedad, temperatura o precipitacion
+    // velocidad, direccion, humedad, temperatura, precipitacion, presion y humedad_suelo
+    private String tipo;
     private String valor;
     private String fecha;
 
@@ -27,6 +28,10 @@ public class Sensor {
                 this.valor = String.format("%.2f", 15 + random.nextDouble() * 25); break;
             case "precipitacion":
                 this.valor = String.format("%.2f", random.nextDouble() * 50); break;
+            case "presion":
+                this.valor = String.format("%.2f", 990 + random.nextDouble() * 40); break;
+            case "humedad_suelo":
+                this.valor = String.format("%.2f", random.nextDouble() * 100); break;
             default:
                 this.valor = "0";
         }

--- a/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
+++ b/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
@@ -72,11 +72,6 @@ public class SuscriptorCallback implements MqttCallback {
 
         String tipo = partes[4];
 
-        // Si el tipo es "presion", lo tratamos como "precipitacion"
-        if (tipo.equals("presion")) {
-            tipo = "precipitacion";
-        }
-
         String sql;
         switch (tipo) {
             case "velocidad":
@@ -93,6 +88,12 @@ public class SuscriptorCallback implements MqttCallback {
                 break;
             case "precipitacion":
                 sql = "INSERT INTO datos_precipitacion (sensor_id, estacion_id, probabilidad, fecha) VALUES (?, ?, ?, ?)";
+                break;
+            case "presion":
+                sql = "INSERT INTO datos_presion (sensor_id, estacion_id, presion, fecha) VALUES (?, ?, ?, ?)";
+                break;
+            case "humedad_suelo":
+                sql = "INSERT INTO datos_humedad_suelo (sensor_id, estacion_id, humedad_suelo, fecha) VALUES (?, ?, ?, ?)";
                 break;
             default:
                 System.out.println("Tipo de sensor desconocido: " + tipo);


### PR DESCRIPTION
## Summary
- add subscriptions for `humedad_suelo`
- simulate `presion` and `humedad_suelo`
- generate values for new sensors
- insert pressure and soil humidity values in the callback

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686d3d99c984832289fbbaca4210ea51